### PR TITLE
FIX: False Instance Call

### DIFF
--- a/src/jquery.whenlive.js
+++ b/src/jquery.whenlive.js
@@ -70,7 +70,7 @@
 
 			if ( MutationObserver ) {
 
-				var observer = new WebKitMutationObserver(function(mutations) {
+				var observer = new MutationObserver(function(mutations) {
 					for ( var mi = 0; mi < mutations.length; mi++ ) {
 						var mutation = mutations[mi];
 						checkElements(mutation.target);


### PR DESCRIPTION
There shouldn't be an instance call to WebKitMutationObserver when the right MutationObserver Object was saved into variable MutationObserver. Without this fix i got an error in firefox
