### PR TITLE
splice calls were emptying whenLiveElements

### DIFF
--- a/src/jquery.whenlive.js
+++ b/src/jquery.whenlive.js
@@ -31,11 +31,11 @@
 					if ( $.whenLiveElements[ek]['elem'].is(':visible') ) {
 						// It's visible.
 						$.whenLiveElements[ek].fn.call($.whenLiveElements[ek].elem);
-						$.whenLiveElements.splice(ek);
+						$.whenLiveElements.splice(ek, 1);
 					}
 				} else {
 					$.whenLiveElements[ek].fn.call($.whenLiveElements[ek].elem);
-					$.whenLiveElements.splice(ek);
+					$.whenLiveElements.splice(ek, 1);
 				}
 			}
 		}


### PR DESCRIPTION
added length parameter to splice calls, to make sure they only remove one item at a time.
